### PR TITLE
fix: view props types in react native web

### DIFF
--- a/src/SwipeRating.js
+++ b/src/SwipeRating.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 import {
   View, Text, Animated, PanResponder, Image,
-  StyleSheet, Platform, ViewPropTypes
+  StyleSheet, Platform
 } from 'react-native';
 
 // RATING IMAGES WITH STATIC BACKGROUND COLOR (white)
@@ -329,7 +329,7 @@ const fractionsType = (props, propName, componentName) => {
 
 SwipeRating.propTypes = {
   type: PropTypes.string,
-  ratingImage: Image.propTypes.source,
+  ratingImage: Image?.propTypes?.source,
   ratingColor: PropTypes.string,
   ratingBackgroundColor: PropTypes.string,
   ratingCount: PropTypes.number,
@@ -338,7 +338,7 @@ SwipeRating.propTypes = {
   onStartRating: PropTypes.func,
   onFinishRating: PropTypes.func,
   showRating: PropTypes.bool,
-  style: ViewPropTypes.style,
+  style: View?.propTypes,
   readonly: PropTypes.bool,
   showReadOnlyText: PropTypes.bool,
   startingValue: PropTypes.number,


### PR DESCRIPTION
The original version has react native web compatibility, fix a small fix to fix this problem, thanks and have a nice week.